### PR TITLE
Added "class" attribute when searching for nodes to check

### DIFF
--- a/newspaper/extractors/articlebody_extractor.py
+++ b/newspaper/extractors/articlebody_extractor.py
@@ -97,10 +97,11 @@ class ArticleBodyExtractor:
         for tag in ["p", "pre", "td", "article", "div"]:
             if tag == "div":
                 items = []
-                for id_ in ["article-body", "article", "story", "article-content"]:
-                    items += self.parser.getElementsByTag(
-                        doc, tag=tag, attr="id", value=id_
-                    )
+                for attr in ["id", "class"]:
+                    for id_ in ["article-body", "article", "story", "article-content"]:
+                        items += self.parser.getElementsByTag(
+                            doc, tag=tag, attr=attr, value=id_
+                        )
             else:
                 items = self.parser.getElementsByTag(doc, tag=tag)
             nodes_to_check += items


### PR DESCRIPTION
There are cases when no nodes are found to be checked. For example: [https://ria.ru/20210129/navalnyy-1595201668.html](https://ria.ru/20210129/navalnyy-1595201668.html)

The reason for this is that the main article is within `<div>` that doesn't have `id` attribute but does have `class="article__body"`

NB: This fix can slow down the parsing a little bit (as it would double the time needed to find the nodes to check) but shouldn't be that dramatic