### PR TITLE
Expose HTTP history to know server redirections

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -253,6 +253,7 @@ class Article:
         self.is_parsed = False
         self.download_state = ArticleDownloadState.NOT_STARTED
         self.download_exception_msg: Optional[str] = None
+        self.history: Optional[List[str]] = []
 
         # Meta description field in the HTML source
         self.meta_description = ""
@@ -317,8 +318,9 @@ class Article:
 
     def _parse_scheme_http(self, url: Optional[str] = None):
         try:
-            html, stauts_code = network.get_html_2XX_only(url or self.url, self.config)
-            if stauts_code >= 400:
+            html, status_code, history = network.get_html_2XX_only(url or self.url, self.config)
+            self.history = history
+            if status_code >= 400:
                 self.download_state = ArticleDownloadState.FAILED_RESPONSE
                 protection = self._detect_protection(html)
                 if protection:
@@ -327,7 +329,7 @@ class Article:
                     )
                 else:
                     self.download_exception_msg = (
-                        f"Status code {stauts_code} for url {url}"
+                        f"Status code {status_code} for url {url}"
                     )
                 return None
         except requests.exceptions.RequestException as e:

--- a/newspaper/network.py
+++ b/newspaper/network.py
@@ -59,7 +59,7 @@ def get_html_2XX_only(url, config=None, response=None):
     if isinstance(html, bytes):
         html = config.get_parser().get_unicode_html(html)
 
-    return html, response.status_code
+    return html, response.status_code, response.history
 
 
 def _get_html_from_response(response, config):


### PR DESCRIPTION
Hi!

I was having troubles downloading some articles from some webs. The main problem was that the webs redirects me from a not existing article to its homepage. 
Newspaper4k inform that response page was 200 but doesn't inform that was a 301 in the middle of navigation so, to not create a bunch of HTTP codes, I thought to expose the HTTP history.

I'm checking the history right now and it works perfect.

e.g The URL `https://newschecker.in/hi/delhi-waterlogging-tea-party/` redirects me to its home `https://newschecker.in/hi/`.