### PR TITLE
fix(misc): fix erroring debug statements

### DIFF
--- a/newspaper/source.py
+++ b/newspaper/source.py
@@ -323,7 +323,7 @@ class Source:
 
     def parse_categories(self):
         """Parse out the lxml root in each category"""
-        log.debug("We are extracting from %d categories", self.categories)
+        log.debug("We are extracting from %d categories", len(self.categories))
         for category in self.categories:
             doc = parsers.fromstring(category.html)
             category.doc = doc
@@ -344,7 +344,7 @@ class Source:
 
     def parse_feeds(self):
         """Add titles to feeds"""
-        log.debug("We are parsing %d feeds", self.feeds)
+        log.debug("We are parsing %d feeds", len(self.feeds))
         self.feeds = [self._map_title_to_feed(f) for f in self.feeds]
 
     def feeds_to_articles(self) -> List[Article]:


### PR DESCRIPTION
Changed two debug statements that were supposed to print a number argument from printing a list to correctly printing the length of the list.

### Related Issues
When calling source.parse_categories() with a debug level logger, I was seeing this error. This was messing up my "look at how fast the logs go" method of performance profiling. 
```
TypeError: %d format: a real number is required, not list
Call stack:
  File "/usr/lib/python3.12/threading.py", line 1030, in _bootstrap
    self._bootstrap_inner()
  File "/usr/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.12/threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 92, in _worker
    work_item.run()
  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/.../scraper.py", line 413, in safe_scrape
    self.scrape_site(site)
  File "/home/.../scraper.py", line 346, in scrape_site
    paper.parse_categories()
  File "/home/.../venv/lib/python3.12/site-packages/newspaper/source.py", line 326, in parse_categories
    log.debug("We are extracting from %d categories", self.categories)
Message: 'We are extracting from %d categories'
Arguments: ([Category(url='...', html='<!DOCTYPE html>
```

### Proposed Changes:
Looks like we weren't printing the length of the lists in a few places. This change corrects that.

### How did you test it?
Run something like this before you scrape a site. 
```
logging.basicConfig(
    level=logging.DEBUG,
    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
    handlers=[
        logging.StreamHandler()
    ]
)
```
Then create a source and run through paper.parse_categories() and paper.parse_feeds(). 

Now it doesn't error!

### Checklist

- [ ] I have updated the related issue with new insights and changes
- [ ] I added unit tests and updated the docstrings
- [X] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/AndyTheFactory/newspaper4k/blob/documentation-update/CONTRIBUTING.md#setup) and fixed any issue
