### PR TITLE
(fix) Scientific American author scraping

### DIFF
--- a/newspaper/extractors/authors_extractor.py
+++ b/newspaper/extractors/authors_extractor.py
@@ -89,7 +89,12 @@ class AuthorsExtractor:
             elif isinstance(vals, list):
                 for val in vals:
                     if isinstance(val, dict):
-                        authors.append(val.get("name"))
+                        name = val.get("name")
+                        if isinstance(name, str):
+                            authors.append(name)
+                        elif isinstance(name, dict):
+                            if "name" in name:
+                                authors.append(name.get("name"))
                     elif isinstance(val, str):
                         authors.append(val)
             elif isinstance(vals, str):


### PR DESCRIPTION
### Related Issues

- fixes #643 

### Proposed Changes:
In the comments for #643 I described how scientific american doesn't put all authors into JSON-LD format. This causes some authors to be in a sub-dict of the name dict. I added a condition to handle the case where name is a dict and not a string gracefully.

### How did you test it?

```
# Create an instance of NewsPaper (replace with the appropriate URL)
article = newspaper.Article("https://www.scientificamerican.com/article/man-survives-with-titanium-heart-for-100-days-a-world-first/")
# Call parse_categories and log output
article.download()
article.parse()
print(article.article_html)
print(article.text)
```

Repeat for a few more articles.

### Checklist

- [X] I have updated the related issue with new insights and changes
- [ ] I added unit tests and updated the docstrings
- [X] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/AndyTheFactory/newspaper4k/blob/documentation-update/CONTRIBUTING.md#setup) and fixed any issue
