### PR TITLE
fix: the configuration fetch_images

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -488,7 +488,14 @@ class Article:
 
         self.set_movies(self.extractor.get_videos(self.doc, self.top_node))
 
-        self.fetch_images()
+        # Only fetch images if fetch_images is True
+        if self.config.fetch_images:
+            self.fetch_images()
+        else:
+            self.meta_img = ""
+            self.top_image = ""
+            self.images = []
+            self.meta_favicon = ""
 
         if self.top_node is not None:
             self._top_node_complemented = document_cleaner.clean(


### PR DESCRIPTION
### Related Issues

- fixes #146 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
There is a bug that when `fetch_images` is set to `False`, it still download images. In `Article.parse()` function, I made a code change to only fetch images if `fetch_images` is `True`.

 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I added two unit tests for this code change.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- [ ] I have updated the related issue with new insights and changes
- [ ] I added unit tests and updated the docstrings
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/AndyTheFactory/newspaper4k/blob/documentation-update/CONTRIBUTING.md#setup) and fixed any issue
