### PR TITLE
docs: fix evaluator script path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ detailed guides using newspaper.
 ## Evaluation Results
 
 
-Using the dataset from [ScrapingHub](https://github.com/scrapinghub/article-extraction-benchmark) I created an [evaluator script](tests/evaluation/evaluate.py) that compares the performance of newspaper against it's previous versions. This way we can see how newspaper updates improve or worsen the performance of the library.
+Using the dataset from [ScrapingHub](https://github.com/scrapinghub/article-extraction-benchmark) I created an [evaluator script](evaluation/evaluate.py) that compares the performance of newspaper against it's previous versions. This way we can see how newspaper updates improve or worsen the performance of the library.
 
 <h3 align="center">Scraperhub Article Extraction Benchmark</h3>
 


### PR DESCRIPTION
I just got OCD from the file not pointing to the correct place. :)

### Related Issues

N/A

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
Issue: README had a small insignificant bug which pointed the evaluator script to a non-existent path
Solved: Pointed the file path to where the evaluator script was moved to.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Manual verification - I.E: I pressed the link to the evaluator script and it pointed to the correct file.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

N/A

### Checklist

- [N/A] I have updated the related issue with new insights and changes
- [N/A] I added unit tests and updated the docstrings
- [X] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [N/A] I documented my code
- [N/A] I ran [pre-commit hooks](https://github.com/AndyTheFactory/newspaper4k/blob/documentation-update/CONTRIBUTING.md#setup) and fixed any issue
