### PR TITLE
feat: Add ISO 639-3 language code support for Kurdish (ckb, kmr)

### DIFF
--- a/newspaper/extractors/metadata_extractor.py
+++ b/newspaper/extractors/metadata_extractor.py
@@ -7,6 +7,7 @@ import lxml
 import newspaper.parsers as parsers
 from newspaper.configuration import Configuration
 from newspaper.extractors.defines import A_HREF_TAG_SELECTOR, A_REL_TAG_SELECTOR, META_LANGUAGE_TAGS, RE_LANG
+from newspaper.languages import ISO639_3_TO_1
 
 
 class MetadataExtractor:
@@ -43,6 +44,13 @@ class MetadataExtractor:
         def get_if_valid(s: Optional[str]) -> Optional[str]:
             if s is None or len(s) < 2:
                 return None
+
+            # Handle ISO 639-3 codes (3 chars) that can be mapped to ISO 639-1
+            s_lower = s[:3].lower()
+            if s_lower in ISO639_3_TO_1:
+                return ISO639_3_TO_1[s_lower]
+
+            # Standard 2-char ISO 639-1 code
             s = s[:2]
             if re.search(RE_LANG, s):
                 return s.lower()

--- a/newspaper/languages/__init__.py
+++ b/newspaper/languages/__init__.py
@@ -188,6 +188,25 @@ languages_tuples = [
 
 languages_dict = {code: language for code, language in languages_tuples}
 
+# Map ISO 639-3 codes to ISO 639-1 codes for languages that contain multiple stop words
+ISO639_3_TO_1 = {
+    "ckb": "ku",  # Central Kurdish (Sorani) -> Kurdish
+    "kmr": "ku",  # Northern Kurdish (Kurmanji) -> Kurdish
+}
+
+
+def normalize_language_code(code: str) -> str:
+    """Normalize ISO 639-3 codes to ISO 639-1 codes.
+
+    Args:
+        code (str): The language code (2 or 3 characters)
+
+    Returns:
+        str: The normalized 2-character ISO 639-1 code
+    """
+    return ISO639_3_TO_1.get(code, code)
+
+
 # See https://www.omniglot.com/writing/ for details
 languages_unicode_regex = {
     "aa": r"\u0600-\u06ff\ufb50-\ufdff\ufe70-\ufefe",

--- a/newspaper/text.py
+++ b/newspaper/text.py
@@ -12,6 +12,7 @@ from unicodedata import category
 from nltk.tokenize import WhitespaceTokenizer
 
 from newspaper import settings
+from newspaper.languages import normalize_language_code
 
 punctuation_set = {c for i in range(sys.maxunicode + 1) if category(c := chr(i)).startswith("P")}
 punctuation_set.update(string.punctuation)
@@ -107,6 +108,9 @@ class StopWords:
     def __init__(self, language="en"):
         self.find_stopwords = None
         self.tokenizer = default_tokenizer
+
+        # Normalize ISO 639-3 codes to ISO 639-1 codes
+        language = normalize_language_code(language)
 
         if language not in self._cached_stop_words:
             stopwords_file = Path(settings.STOPWORDS_DIR) / f"stopwords-{language}.txt"

--- a/tests/unit/test_languages.py
+++ b/tests/unit/test_languages.py
@@ -1,7 +1,11 @@
 import pytest
 
 from newspaper.article import Article
+from newspaper.configuration import Configuration
 from newspaper.text import StopWords
+from newspaper.languages import normalize_language_code, ISO639_3_TO_1
+from newspaper.extractors.metadata_extractor import MetadataExtractor
+import newspaper.parsers as parsers
 from tests import conftest
 
 
@@ -56,3 +60,54 @@ class TestLanguages:
         stat = stopwords.get_stopword_count(text)
 
         assert stat.stop_word_count == 33, "Stopwords count for np is not correct"
+
+    def test_normalize_language_code(self):
+        """Test that ISO 639-3 codes are normalized to ISO 639-1"""
+        # Kurdish variants should map to 'ku'
+        assert normalize_language_code("ckb") == "ku"
+        assert normalize_language_code("kmr") == "ku"
+        # Standard 2-char codes should remain unchanged
+        assert normalize_language_code("ku") == "ku"
+        assert normalize_language_code("en") == "en"
+        assert normalize_language_code("ar") == "ar"
+
+    def test_iso639_3_to_1_map_contains_kurdish(self):
+        """Test that the mapping contains Kurdish variants"""
+        assert "ckb" in ISO639_3_TO_1
+        assert "kmr" in ISO639_3_TO_1
+        assert ISO639_3_TO_1["ckb"] == "ku"
+        assert ISO639_3_TO_1["kmr"] == "ku"
+
+    def test_stopwords_with_kurdish_iso639_3_codes(self):
+        """Test that StopWords works with ISO 639-3 Kurdish codes"""
+        # All three codes should load the same stopwords
+        stopwords_ku = StopWords("ku")
+        stopwords_ckb = StopWords("ckb")
+        stopwords_kmr = StopWords("kmr")
+
+        assert stopwords_ku.stop_words == stopwords_ckb.stop_words
+        assert stopwords_ku.stop_words == stopwords_kmr.stop_words
+        assert len(stopwords_ku.stop_words) > 0
+
+    def test_metadata_extractor_kurdish_language_detection(self):
+        """Test that MetadataExtractor correctly detects Kurdish ISO 639-3 codes"""
+        config = Configuration()
+        extractor = MetadataExtractor(config)
+
+        # Test ckb (Central Kurdish/Sorani)
+        html_ckb = '<html lang="ckb"><head></head><body></body></html>'
+        doc_ckb = parsers.fromstring(html_ckb)
+        metadata_ckb = extractor.parse("http://example.com", doc_ckb)
+        assert metadata_ckb["language"] == "ku"
+
+        # Test kmr (Northern Kurdish/Kurmanji)
+        html_kmr = '<html lang="kmr"><head></head><body></body></html>'
+        doc_kmr = parsers.fromstring(html_kmr)
+        metadata_kmr = extractor.parse("http://example.com", doc_kmr)
+        assert metadata_kmr["language"] == "ku"
+
+        # Test standard ku code still works
+        html_ku = '<html lang="ku"><head></head><body></body></html>'
+        doc_ku = parsers.fromstring(html_ku)
+        metadata_ku = extractor.parse("http://example.com", doc_ku)
+        assert metadata_ku["language"] == "ku"


### PR DESCRIPTION
### Proposed Changes:

Added support for ISO 639-3 language codes that share stopwords with existing ISO 639-1 codes. Specifically:

•  Added ISO639_3_TO_1 mapping dictionary in newspaper/languages/__init__.py to map 3-character codes to 2-character codes
•  Added normalize_language_code() utility function for consistent code normalization
•  Updated MetadataExtractor._get_meta_language() to detect ISO 639-3 codes (e.g., ckb, kmr) from HTML lang attributes and convert them to their ISO 639-1 equivalents
•  Updated StopWords class to normalize language codes before loading stopwords

This allows Kurdish variants (ckb - Central Kurdish/Sorani, kmr - Northern Kurdish/Kurmanji) to use the existing stopwords-ku.txt file.

### How did you test it?

Added 4 unit tests in tests/unit/test_languages.py:
•  test_normalize_language_code - verifies ISO 639-3 to ISO 639-1 normalization
•  test_iso639_3_to_1_map_contains_kurdish - verifies mapping dictionary contents
•  test_stopwords_with_kurdish_iso639_3_codes - verifies StopWords works with ku, ckb, kmr
•  test_metadata_extractor_kurdish_language_detection - verifies HTML language detection for Kurdish codes

Run tests: pytest tests/unit/test_languages.py -v -k "kurdish or normalize or iso639"

### Notes for the reviewer

The mapping is extensible - other ISO 639-3 codes can be added to ISO639_3_TO_1 dictionary as needed.

### Checklist

- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.