### PR TITLE
fix: skip null entries in JSON-LD arrays during extraction (#692)

### DIFF
--- a/newspaper/parsers.py
+++ b/newspaper/parsers.py
@@ -311,7 +311,7 @@ def get_ld_json_object(node):
             except Exception:
                 continue
             if isinstance(schema_json, list):
-                res.extend(schema_json)
+                res.extend(item for item in schema_json if isinstance(item, dict))
             else:
                 res.append(schema_json)
 

--- a/tests/unit/test_article.py
+++ b/tests/unit/test_article.py
@@ -159,6 +159,19 @@ class TestArticle:
 
         assert len(errors) == 0, f"Test case failed on : {errors}"
 
+    def test_json_ld_with_null_entries(self):
+        html = (
+            "<html><head>"
+            '<script type="application/ld+json">'
+            '[{"@type":"Article","headline":"Test"}, null]'
+            "</script>"
+            "</head><body><p>Hello world</p></body></html>"
+        )
+        article = Article("http://example.com", fetch_images=False)
+        article.download(input_html=html)
+        article.parse()
+        assert isinstance(article.authors, list)
+
     def test_pickle(self, cnn_article):
         article = newspaper.article(
             cnn_article["url"],


### PR DESCRIPTION
### Related Issues

fixes #692

### Proposed Changes:

`parsers.get_ld_json_object()` calls `res.extend(schema_json)` when a JSON-LD script tag contains a JSON array. If that array contains `null` entries, they end up as `None` in the result list. Downstream in `authors_extractor.py`, the code does `if "@graph" in script_tag` on each entry without checking for non-dict types, which raises `TypeError` on `None`.

The fix filters out non-dict entries at the source in `parsers.py` when extending from a parsed JSON-LD list.

### How did you test it?

- Added a unit test (`test_json_ld_with_null_entries`) that parses HTML containing a JSON-LD array with a null element and verifies `article.parse()` completes without error

### Notes for the reviewer

The fix is a one-line change in `newspaper/parsers.py:314`. Filtering at the source (`get_ld_json_object`) rather than adding guards in each consumer keeps things simple and prevents similar issues elsewhere.

### Checklist

  - [x] I have updated the related issue with new insights and changes
  - [x] I added unit tests and updated the docstrings
  - [x] I've used one of the conventional commit types for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
  - [ ] I documented my code
  - [ ] I ran pre-commit hooks and fixed any issue (appeared to be pre-existing styling hints)
