### PR TITLE
fix: relax lxml upper bound to allow 6.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "Pillow >=12.0.0; python_version >= '3.14'",
   "Pillow >=4.0.0; python_version < '3.14'",
   "PyYAML >=5.1",
-  "lxml[html_clean] >=5.2.0,<6.0.0",
+  "lxml[html_clean] >=5.2.0,<7.0.0",
   "requests >=2.26.0,<3.0.0",
   "feedparser >=6.0.2,<7.0.0",
   "tldextract >=5.0.0,<6.0.0",


### PR DESCRIPTION
Relax lxml upper bound from `<6.0.0` to `<7.0.0`.

lxml 6.x is fully compatible — tested Article download, parse, and text extraction with lxml 6.0.2. The current pin blocks Python 3.14 users since lxml 5.x has no pre-built wheels for that version.